### PR TITLE
Add scale-factor calculation when scale-to-fit is enabled

### DIFF
--- a/packages/core/app/pages/Function.js
+++ b/packages/core/app/pages/Function.js
@@ -34,17 +34,30 @@ export const Function = ({ name, exports: functionExports, children }) => {
 
   const prepareValues = (useScale, useRandomSeed) => {
     const valuesCopy = Object.assign({}, values);
+    valuesCopy.scaleToFit = {
+      widthOriginal: values.width,
+      heightOriginal: values.height,
+      width: values.width,
+      height: values.height,
+      factor: 1,
+    };
     if (useScale && canScale && scaleToFit) {
       const bounds = mainRef.current.getBoundingClientRect();
-      valuesCopy.scaleToFit = {
-        width: bounds.width - 100,
-        height: bounds.height - 100
-      };
+      const availableWidth = bounds.width - 100
+      const availableHeight = bounds.height - 100
+      valuesCopy.scaleToFit.width = availableWidth < values.width ? availableWidth : values.width;
+      valuesCopy.scaleToFit.height = availableHeight < values.height ? availableHeight : values.height;
+      valuesCopy.scaleToFit.factor = valuesCopy.scaleToFit.width / values.width
     }
     if (useRandomSeed && lastRun.current?.values) {
       valuesCopy.randomSeed = lastRun.current.values.randomSeed;
     }
     return valuesCopy;
+  };
+
+  const handleScaleToFit = () => {
+    setScaleToFit(!scaleToFit);
+    iframe.current.contentWindow?.dispatchEvent?.(new CustomEvent('scaleToFit', { detail: { scaleToFit: !scaleToFit } }));
   };
 
   const handlePreview = async () => {
@@ -111,7 +124,7 @@ export const Function = ({ name, exports: functionExports, children }) => {
             <Toggle
               status={canScale && scaleToFit}
               disabled={!canScale}
-              onClick={() => setScaleToFit(scaleToFit => !scaleToFit)}>
+              onClick={handleScaleToFit}>
               {canScale ? (scaleToFit ? "Scale to fit On" : "Scale to fit Off") : "Scale to Fit"}
             </Toggle>
             {!canScale && <span className={css.error}>Inputs missing for scaling</span>}


### PR DESCRIPTION
When you export dom-elements that use pixel values in styling, you need to account for the scale factor so the sizes of all elements look the same in both the full-size preview and the downscaled preview. This update ensures that the scale factor is sent to the handler along with the scaleToFit input prop.